### PR TITLE
changing api routes to show only necessary User info (hiding secrets …

### DIFF
--- a/client/components/user-home.js
+++ b/client/components/user-home.js
@@ -6,11 +6,11 @@ import {connect} from 'react-redux'
  * COMPONENT
  */
 export const UserHome = props => {
-  const {email} = props
+  const {userID} = props
 
   return (
     <div>
-      <h3>Welcome, {email}</h3>
+      <h3>Welcome, {userID}</h3>
     </div>
   )
 }
@@ -20,7 +20,7 @@ export const UserHome = props => {
  */
 const mapState = state => {
   return {
-    email: state.user.email
+    userID: state.user.userID
   }
 }
 
@@ -30,5 +30,5 @@ export default connect(mapState)(UserHome)
  * PROP TYPES
  */
 UserHome.propTypes = {
-  email: PropTypes.string
+  userID: PropTypes.string
 }

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -8,7 +8,7 @@ router.get('/', async (req, res, next) => {
       // explicitly select only the id and email fields - even though
       // users' passwords are encrypted, it won't help if we just
       // send everything to anyone who asks!
-      attributes: ['id', 'email']
+      attributes: ['id', 'email', 'userID']
     })
     res.json(users)
   } catch (err) {


### PR DESCRIPTION
…in Sequelize)

----------- changing API routes for "hiding secrets in Sequelize following authentication videos --------
when checking [[localhost](http://localhost:8080/api/users)](url) now id, email, and userID should show

### Assignee Tasks

* [ ] added unit tests (or none needed)
* [ ] written relevant docs (or none needed)
* [ ] referenced any relevant issues (or none exist)

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

_Your PR Notes Here_
